### PR TITLE
add routeProps and overridePathParams options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2019-09-13
+### Changed
+- `useRoutes` second parameter from `basePath` to `options`
+### Added
+- `useRoutes` option `routeProps`
+- `useRoutes` option `overridePathParams`
+
 ## [0.4.0] - 2019-09-12
 ### Added
 - `useBasePath` hook to retrieve the basePath

--- a/README.md
+++ b/README.md
@@ -90,11 +90,15 @@ Some routing libraries only trigger React component updates if navigation was tr
 
 This hook is the main entry point for raviger.
 
-* **useRoutes(routeMap, basePath): Route**
+* **useRoutes(routeMap, { basePath, routeProps, overridePathParams }): Route**
 
 The first parameter is an object of path keys whose values are functions that return a **ReactElement**. The paths should start with a forward-slash `/` and then contain literal matches (`/base`), path variables (`/:userId`), and a `*` for catch-all wildcards. 
 
-The second parameter can be a `basePath` that all routes must begin with, and all `Link`s in the sub-tree will be prepended with. This can be used for sites hosted at a base path, or for nested routers.
+### Options
+
+* **basePath** a `basePath` that all routes must begin with, and all `Link`s in the sub-tree will be prepended with. This can be used for sites hosted at a base path, or for nested routers.
+* **routeProps** additional props to pass to the matched route. They will be merged into any path parameters that are matched with the route.
+* **overridePathParams** (_default: true_) If `true` **routeProps** will override path parameters of the same name when passed to the matched route. If `false` the path parameters will be override **routeProps** of the same name.
 
 ## **navigate**
 

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -42,7 +42,7 @@ const deepRoutes = {
 }
 
 function Deep() {
-  let route = useRoutes(deepRoutes, '/deep')
+  let route = useRoutes(deepRoutes, { basePath: '/deep' })
   return (
     <div>
       <Nav>


### PR DESCRIPTION
Adds new options to `useRoutes` for passing additional props to the matched route component.

This is a **breaking change** to the `useRoutes` signature

closes #10 