### PR TITLE
always useLocationChange in usePath

### DIFF
--- a/src/path.js
+++ b/src/path.js
@@ -4,13 +4,9 @@ import { isNode, getSsrPath } from './node.js'
 import { isFunction } from './typeChecks.js'
 
 export function usePath(basePath) {
-  let context = useRouter()
-  let [path, setPath] = useState(context.path || getCurrentPath(basePath))
-  useLocationChange(setPath, {
-    basePath,
-    isActive: !context.path
-  })
-  return context.path || path
+  let [path, setPath] = useState(getCurrentPath(basePath || useBasePath()))
+  useLocationChange(setPath, { basePath })
+  return path
 }
 
 export function useBasePath() {

--- a/test/path.spec.js
+++ b/test/path.spec.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render, act } from '@testing-library/react'
-import { useLocationChange, navigate } from '../src/main.js'
+import { useRoutes, usePath, useLocationChange, navigate } from '../src/main.js'
 
 beforeEach(() => {
   act(() => navigate('/'))
@@ -26,5 +26,59 @@ describe('useLocationChange', () => {
     act(() => navigate('/foo'))
 
     expect(watcher).not.toBeCalled()
+  })
+})
+
+describe('usePath', () => {
+  function Route() {
+    let path = usePath()
+    return <span data-testid="path">{path}</span>
+  }
+  test('returns original path', async () => {
+    act(() => navigate('/'))
+    const { getByTestId } = render(<Route />)
+
+    expect(getByTestId('path')).toHaveTextContent('/')
+  })
+
+  test('returns updated path', async () => {
+    act(() => navigate('/'))
+    const { getByTestId } = render(<Route />)
+    act(() => navigate('/about'))
+
+    expect(getByTestId('path')).toHaveTextContent('/about')
+  })
+
+  test('does not include parent router base path', async () => {
+    function Harness({ routes, basePath }) {
+      const route = useRoutes(routes, { basePath })
+      return route
+    }
+
+    const nestedRoutes = {
+      '/': () => <Route />,
+      '/about': () => <Route />
+    }
+    const routes = {
+      '/': () => <Route />,
+      '/about': () => <Route />,
+      '/nested*': () => <Harness basePath="/nested" routes={nestedRoutes} />
+    }
+
+    const { getByTestId } = render(<Harness routes={routes} />)
+    act(() => navigate('/'))
+    expect(getByTestId('path')).toHaveTextContent('/')
+
+    act(() => navigate('/about'))
+    expect(getByTestId('path')).toHaveTextContent('/about')
+
+    act(() => navigate('/nested/about'))
+    expect(getByTestId('path')).toHaveTextContent('/about')
+
+    // Yes, check twice
+    // This is a regression check for this bug: https://github.com/kyeotic/raviger/issues/34
+    act(() => navigate('/nested/about'))
+    expect(getByTestId('path')).toHaveTextContent('/about')
+    expect(getByTestId('path')).not.toHaveTextContent('/nested')
   })
 })

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -129,54 +129,6 @@ describe('useRoutes', () => {
   })
 })
 
-describe('usePath', () => {
-  function Route() {
-    let path = usePath()
-    return <span data-testid="path">{path}</span>
-  }
-  test('returns original path', async () => {
-    act(() => navigate('/'))
-    const { getByTestId } = render(<Route />)
-
-    expect(getByTestId('path')).toHaveTextContent('/')
-  })
-
-  test('returns updated path', async () => {
-    act(() => navigate('/'))
-    const { getByTestId } = render(<Route />)
-    act(() => navigate('/about'))
-
-    expect(getByTestId('path')).toHaveTextContent('/about')
-  })
-
-  test('does not include parent router base path', async () => {
-    function Harness({ routes, basePath }) {
-      const route = useRoutes(routes, { basePath })
-      return route
-    }
-
-    const nestedRoutes = {
-      '/': () => <Route />,
-      '/about': () => <Route />
-    }
-    const routes = {
-      '/': () => <Route />,
-      '/about': () => <Route />,
-      '/nested*': () => <Harness basePath="/nested" routes={nestedRoutes} />
-    }
-
-    const { getByTestId } = render(<Harness routes={routes} />)
-    act(() => navigate('/'))
-    expect(getByTestId('path')).toHaveTextContent('/')
-
-    act(() => navigate('/about'))
-    expect(getByTestId('path')).toHaveTextContent('/about')
-
-    act(() => navigate('/nested/about'))
-    expect(getByTestId('path')).toHaveTextContent('/about')
-  })
-})
-
 describe('useBasePath', () => {
   function Harness({ routes, basePath }) {
     const route = useRoutes(routes, { basePath })


### PR DESCRIPTION
fixes #34 

---

`usePath` became needlessly complicated after the `useLocationChange` introduction, relying on both the router context and the location watcher for its path. It only used the inherited `basePath` in one code path, creating inconsistent behavior.