### PR TITLE
Fix wrong dependencies when memoizing routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ example/dist/*
 /themes/
 
 # misc
+.idea
 .DS_Store
 .env.local
 .env.development.local

--- a/src/router.js
+++ b/src/router.js
@@ -45,10 +45,9 @@ function matchRoute(
   if (matchTrailingSlash && path && path[path.length - 1] === '/') {
     path = path.substring(0, path.length - 1)
   }
-  const routePaths = Object.keys(routes)
   const routeMatchers = useMemo(
-    () => routePaths.map(createRouteMatcher),
-    routePaths
+    () => Object.keys(routes).map(createRouteMatcher),
+    [routes]
   )
   // Hacky method for find + map
   let routeMatch

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -127,6 +127,40 @@ describe('useRoutes', () => {
     act(() => navigate('/users/1'))
     expect(getByTestId('label')).toHaveTextContent('User 1')
   })
+
+  test('handles dynamic routes', async () => {
+    const Harness = () => {
+      const [myRoutes, setRoutes] = React.useState(routes)
+
+      const addNewRoute = () => {
+        setRoutes(prevRoutes => {
+          return {
+            ...prevRoutes,
+            '/new': () => <Route label="new route" />
+          }
+        })
+      }
+
+      const route = useRoutes(myRoutes) || <span data-testid="label">not found</span>
+
+      return (
+        <>
+          {route}
+          <button onClick={addNewRoute} data-testid="add-route">Add route</button>
+        </>
+      )
+    }
+
+    const { getByTestId } = render(<Harness/>)
+    act(() => navigate('/new'));
+    expect(getByTestId('label')).not.toHaveTextContent('new route')
+
+    const button = getByTestId('add-route')
+
+    act(() => button.click())
+    act(() => navigate('/new'));
+    expect(getByTestId('label')).toHaveTextContent('new route')
+  })
 })
 
 describe('useBasePath', () => {


### PR DESCRIPTION
I've found a small bug related to the usage of `useMemo` and how the dependencies are passed.

The issue will occur only when we extend the `routes` object with a new route that will change the size of the array and trigger React warning:
```
      Warning: The final argument passed to useMemo changed size between renders. The order and size of this array must remain constant.

      Previous: [/, /about, /users/:userId]
      Incoming: [/, /about, /users/:userId, /new]
          in Harness
```