### PR TITLE
Navigate adds extra entries to history when using the Redirect component

### DIFF
--- a/src/navigate.js
+++ b/src/navigate.js
@@ -4,20 +4,18 @@ import { isNode } from './node.js'
 const defaultPrompt = 'Are you sure you want to leave this page?'
 const interceptors = new Set()
 
-export function navigate(url, replaceOrQuery = false, replace = false) {
+export function navigate(url, queryParams = false, replace = false) {
   if (typeof url !== 'string') {
     throw new Error(`"url" must be a string, was provided a(n) ${typeof url}`)
   }
-  if (Array.isArray(replaceOrQuery)) {
+  if (Array.isArray(queryParams)) {
     throw new Error(
-      '"replaceOrQuery" must be boolean, object, or URLSearchParams'
+      '"queryParams" must be boolean, object, or URLSearchParams'
     )
   }
   if (shouldCancelNavigation()) return
-  if (replaceOrQuery !== null && typeof replaceOrQuery === 'object') {
-    url += '?' + new URLSearchParams(replaceOrQuery).toString()
-  } else {
-    replace = replaceOrQuery
+  if (queryParams !== null && typeof queryParams === 'object') {
+    url += '?' + new URLSearchParams(queryParams).toString()
   }
   window.history[`${replace ? 'replace' : 'push'}State`](null, null, url)
   dispatchEvent(new PopStateEvent('popstate', null))


### PR DESCRIPTION
This fix removes code which causes replace to be falsey in conditions where queryParams is not an object.

## Details
In this simple example, I want any request to `/` to redirect to `/user/dashboard` as that is the default url for my example app.

```
const routes = {
  '/': () => <Redirect to="/user/dashboard" />,
  '/user/dashboard*': () => <Dashboard />,
  '/user/settings*': () => <Settings />
};
```

When I open a new tab and visit `/` I am routed to `/user/dashboard` but I get two history entries:
<img width="352" alt="Screen Shot 2020-07-31 at 12 22 16 PM" src="https://user-images.githubusercontent.com/56841696/89072038-b19b7b00-d32c-11ea-8da0-4eccbeacf22d.png">


I traced this issue to this line https://github.com/kyeotic/raviger/blob/master/src/navigate.js#L20 Since `replaceOrQuery` is null, `replace` gets set to `null`. I can't deduce what purpose this line has as the only location that `navigate` is being called with more than 1 parameter is here https://github.com/kyeotic/raviger/blob/master/src/redirect.js#L16 and it is only being passed as `queryParams`

In this example it is being called as `navigate('/user/dashboard', null, true)`. According to the code in `navigate.js` in all cases other than when `queryParams` is a proper object `replace` will be set to something falsey even if it needs to be true to work properly.