### PR TITLE
Add a hook for navigating with the basePath

### DIFF
--- a/docs/content/api/navigate.md
+++ b/docs/content/api/navigate.md
@@ -17,6 +17,8 @@ export function navigate(
 ): void
 {{< /highlight >}}
 
+**Note**: `navigate` does not consider any `basePath` that may be set.  The `useNavigate` hook should be used if you want to prepend the `basePath` to the URL when navigating.
+
 ## Basic
 
 the `navigate` function is intended to be used outside of components to perform page navigation programmatically. 

--- a/docs/content/api/useNavigate.md
+++ b/docs/content/api/useNavigate.md
@@ -1,0 +1,55 @@
+---
+title: "useNavigate"
+date: 2020-10-22T14:27:55-06:00
+weight: 5
+---
+
+A hook for imperative route changes that include any configured `basePath`
+
+## API
+
+{{< highlight typescript >}}
+type NavigateWithReplace = (url: string, replace?: boolean) => void;
+type NavigateWithQuery = (url: string, query?: URLSearchParams, replace?: boolean) => void;
+
+export function useNavigate(optBasePath?: string): NavigateWithReplace & NavigateWithQuery;
+{{< /highlight >}}
+
+The function returned by `useNavigate` has the same signature as the non-hook [navigate function](/api/navigate).  The only difference is that this function considers the `basePath` when navigating.
+
+## Basic
+
+{{< highlight jsx >}}
+import { useRoutes, useNavigate } from 'raviger'
+
+function Home () {
+  const navigate = useNavigate()
+
+  // pathname will be /app/about after navigation
+  return <button onClick={() => navigate('/about')}>about</button>
+}
+
+function About () {
+  const navigate = useNavigate()
+
+  // pathname will be /app/ after navigation
+  return <button onClick={() => navigate('/')}>home</button>
+}
+
+const routes = {
+  '/': () => <Home />
+  '/about': () => <About />
+}
+
+export default function App() {
+  return useRoutes(routes, { basePath: '/app' })
+}
+{{< /highlight >}}
+
+## Outside a Router
+
+If the `useNavigate` hook is used inside a router context (there is a `useRoutes` in its parent heirarchy), the `basePath` will be inherited.  If the hook is used outside a router context, or if you want to override the `basePath`, you can call the `useNavigate` hook with an `optBasePath` argument.
+
+## Query Params and Replacing State
+
+As with the non-hook `navigate` function, the function returned by `useNavigate` can be called with query params or with a boolean indicating whether to replace the current history entry rather than adding to the history.

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     {
       "webpack": false,
       "path": "dist/module.js",
-      "limit": "4kb"
+      "limit": "4.1kb"
     }
   ]
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 export { useRoutes } from './router.js'
 export { useRedirect, Redirect } from './redirect.js'
 export { default as Link, ActiveLink } from './Link.js'
-export { navigate, useNavigationPrompt } from './navigate.js'
+export { navigate, useNavigate, useNavigationPrompt } from './navigate.js'
 export { usePath, useHash, useBasePath, useLocationChange } from './path.js'
 export { useQueryParams } from './querystring.js'

--- a/src/navigate.js
+++ b/src/navigate.js
@@ -1,5 +1,6 @@
-import { useEffect } from 'react'
+import { useCallback, useEffect } from 'react'
 import { isNode } from './node.js'
+import { useBasePath } from './path.js'
 
 const defaultPrompt = 'Are you sure you want to leave this page?'
 const interceptors = new Set()
@@ -65,4 +66,17 @@ function cancelNavigation(event, prompt) {
   event.returnValue = prompt
   // Return value for prompt per spec
   return prompt
+}
+
+export function useNavigate(optBasePath = '') {
+  const basePath = useBasePath()
+  const navigateWithBasePath = useCallback(
+    (url, replaceOrQuery, replace) => {
+      const base = optBasePath || basePath
+      const href = url.startsWith('/') ? base + url : url
+      navigate(href, replaceOrQuery, replace)
+    },
+    [basePath, optBasePath]
+  )
+  return navigateWithBasePath
 }

--- a/test/navigate.spec.js
+++ b/test/navigate.spec.js
@@ -1,6 +1,11 @@
 import React from 'react'
 import { render, act } from '@testing-library/react'
-import { useNavigationPrompt, navigate } from '../src/main.js'
+import {
+  useNavigationPrompt,
+  useRoutes,
+  useNavigate,
+  navigate
+} from '../src/main.js'
 
 const originalConfirm = window.confirm
 const originalReplaceState = window.history.replaceState
@@ -17,6 +22,121 @@ afterEach(() => {
   window.confirm = originalConfirm
   window.history.replaceState = originalReplaceState
   window.history.pushState = originalPushState
+})
+
+describe('useNavigate', () => {
+  function Route({ newPath, query, replace }) {
+    const navigateWithBasePath = useNavigate()
+    return (
+      <button
+        onClick={() => {
+          navigateWithBasePath(newPath, query, replace)
+        }}
+      >
+        click to navigate
+      </button>
+    )
+  }
+
+  const routes = {
+    '/*': ({ newPath, query, replace }) => (
+      <Route newPath={newPath} query={query} replace={replace} />
+    )
+  }
+
+  function App({ basePath, newPath, query, replace }) {
+    const route = useRoutes(routes, {
+      basePath,
+      routeProps: { newPath, query, replace }
+    })
+    return route
+  }
+
+  test('navigate with a basePath', async () => {
+    const basePath = '/base'
+    const newPath = '/path'
+
+    const { container } = render(<App basePath={basePath} newPath={newPath} />)
+    act(() => navigate(`${basePath}/`))
+
+    const button = container.querySelector('button')
+    act(() => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(document.location.pathname).toEqual(basePath + newPath)
+  })
+
+  test('navigate without a basePath', async () => {
+    const newPath = '/path'
+
+    const { container } = render(<App newPath={newPath} />)
+    act(() => navigate('/'))
+
+    const button = container.querySelector('button')
+    act(() => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(document.location.pathname).toEqual(newPath)
+  })
+
+  test('navigate to a relative path', async () => {
+    const basePath = '/base'
+    const newPath = 'relative'
+
+    const { container } = render(<App basePath={basePath} newPath={newPath} />)
+    act(() => navigate(`${basePath}/page`))
+
+    const button = container.querySelector('button')
+    act(() => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(document.location.pathname).toEqual(`${basePath}/${newPath}`)
+  })
+
+  test('navigate with a query', async () => {
+    const basePath = '/base'
+    const newPath = '/path'
+    const query = { foo: 'bar' }
+
+    const { container } = render(
+      <App basePath={basePath} newPath={newPath} query={query} />
+    )
+    act(() => navigate(`${basePath}/`))
+
+    const button = container.querySelector('button')
+    act(() => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(document.location.pathname).toEqual(basePath + newPath)
+    expect(document.location.search).toEqual('?foo=bar')
+  })
+
+  test('navigate without history', async () => {
+    const basePath = '/base'
+    const newPath = '/path'
+
+    const { container } = render(
+      <App basePath={basePath} newPath={newPath} replace />
+    )
+    act(() => navigate(`${basePath}/`))
+
+    window.history.replaceState = jest.fn()
+    const button = container.querySelector('button')
+    act(() => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(window.history.replaceState.mock.calls).toHaveLength(1)
+    expect(window.history.replaceState.mock.calls[0]).toHaveLength(3)
+    expect(window.history.replaceState.mock.calls[0][2]).toEqual(
+      basePath + newPath
+    )
+    jest.clearAllMocks()
+  })
 })
 
 describe('useNavigationPrompt', () => {

--- a/types/raviger.d.ts
+++ b/types/raviger.d.ts
@@ -45,6 +45,11 @@ export function navigate(
   replace?: boolean
 ): void
 
+type NavigateWithReplace = (url: string, replace?: boolean) => void;
+type NavigateWithQuery = (url: string, query?: URLSearchParams | QueryParam, replace?: boolean) => void;
+
+export function useNavigate(optBasePath?: string): NavigateWithReplace & NavigateWithQuery;
+
 export function usePath(basePath?: string): string
 export function useHash(options?: { stripHash?: boolean }): string
 


### PR DESCRIPTION
This adds a `useNavigate` hook that provides a navigate function that includes the `basePath` (making it more consistent with the `Link` href).

I understand this addition to the API might not be wanted, but I found the existing behavior of `navigate` surprising and thought I'd propose an addition (see https://github.com/kyeotic/raviger/issues/73#issuecomment-714084441).