### PR TITLE
Allow Node 15 usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "types/"
   ],
   "engines": {
-    "node": ">=10.0.0 <15.0.0"
+    "node": ">=10.0.0"
   },
   "types": "types/raviger.d.ts",
   "keywords": [


### PR DESCRIPTION
Hi 👋

A member in our team uses Node v15 and notices that `raviger` is angry about it. Is that something really tied to the library or can we remove this limitation?

Thanks 🙂