### PR TITLE
Fixes bug where scroll position is not maintained when nav is canceled from browser back button

### DIFF
--- a/src/intercept.js
+++ b/src/intercept.js
@@ -4,8 +4,10 @@ export const defaultPrompt = 'Are you sure you want to leave this page?'
 
 let hasIntercepted = false
 let hasUserCancelled = false
+let lastScroll = [0, 0]
 
 export function shouldCancelNavigation() {
+  lastScroll = [window.scrollX, window.scrollY]
   if (hasIntercepted) return hasUserCancelled
   // confirm if any interceptors return true
   return Array.from(interceptors).some(interceptor => {
@@ -22,6 +24,10 @@ export function shouldCancelNavigation() {
     }, 5)
     return hasUserCancelled
   })
+}
+
+export function getLastScroll() {
+  return lastScroll
 }
 
 export function addInterceptor(handler) {

--- a/src/intercept.js
+++ b/src/intercept.js
@@ -26,10 +26,6 @@ export function shouldCancelNavigation() {
   })
 }
 
-export function getLastScroll() {
-  return lastScroll
-}
-
 export function addInterceptor(handler) {
   window.addEventListener('beforeunload', handler)
   interceptors.add(handler)
@@ -38,4 +34,11 @@ export function addInterceptor(handler) {
 export function removeInterceptor(handler) {
   window.removeEventListener('beforeunload', handler)
   interceptors.delete(handler)
+}
+
+export function undoNavigation(lastPath) {
+  window.history.pushState(null, null, lastPath)
+  setTimeout(() => {
+    window.scrollTo(...lastScroll)
+  }, 0)
 }

--- a/src/navigate.js
+++ b/src/navigate.js
@@ -5,7 +5,8 @@ import {
   shouldCancelNavigation,
   addInterceptor,
   removeInterceptor,
-  defaultPrompt
+  defaultPrompt,
+  getLastScroll
 } from './intercept'
 
 let lastPath = ''
@@ -28,6 +29,7 @@ export function navigate(url, replaceOrQuery, replace, state = null) {
     replace = false
   }
   lastPath = url
+
   window.history[`${replace ? 'replace' : 'push'}State`](state, null, url)
   dispatchEvent(new PopStateEvent('popstate', null))
 }
@@ -38,6 +40,9 @@ export function useNavigationPrompt(predicate = true, prompt = defaultPrompt) {
     const onPopStateNavigation = () => {
       if (shouldCancelNavigation()) {
         window.history.pushState(null, null, lastPath)
+        setTimeout(() => {
+          window.scrollTo(...getLastScroll())
+        }, 0)
       }
     }
     window.addEventListener('popstate', onPopStateNavigation)

--- a/src/navigate.js
+++ b/src/navigate.js
@@ -6,7 +6,7 @@ import {
   addInterceptor,
   removeInterceptor,
   defaultPrompt,
-  getLastScroll
+  undoNavigation
 } from './intercept'
 
 let lastPath = ''
@@ -39,10 +39,7 @@ export function useNavigationPrompt(predicate = true, prompt = defaultPrompt) {
   useLayoutEffect(() => {
     const onPopStateNavigation = () => {
       if (shouldCancelNavigation()) {
-        window.history.pushState(null, null, lastPath)
-        setTimeout(() => {
-          window.scrollTo(...getLastScroll())
-        }, 0)
+        undoNavigation(lastPath)
       }
     }
     window.addEventListener('popstate', onPopStateNavigation)


### PR DESCRIPTION
This is because the scroll history for the previous page is applied when the popstate event occurs from the browser back button click, but is not reversed when the pushState re-adds the last path back to history