### PR TITLE
fix: terser treating location as a local variable

### DIFF
--- a/src/querystring.ts
+++ b/src/querystring.ts
@@ -53,5 +53,5 @@ export function getQueryString(): string {
     const queryIndex = ssrPath.indexOf('?')
     return queryIndex === -1 ? '' : ssrPath.substring(queryIndex + 1)
   }
-  return location.search
+  return window.location.search
 }


### PR DESCRIPTION
This solves an issue I've been seeing where `location.search` will sometimes be transformed into `undefined.search` by terser.

This change also brings the location reference in querystring.ts to match those in path.ts and navigate.ts