### PR TITLE
V4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0] - Unreleased
+### Added
+- `useHistory`
+- **BREAKING**: `useLocationChange` is a new hook that uses a `window.location`-like object instead of the _path_
+- `usePath`
+### Changed
+- **BREAKING**: `navigate` now has `options` object instead of overloads
+- **BREAKING**: `useNavigate` uses updated `navigate` params
+- **BREAKING**: `useLocationChange` has been renamed to `usePath`### Fixed
+### Fixed
+-  `usePath` getting an old path if `navigate` was called during the initial render
+
 ## [3.1.0] - 2022-01-17
 ### Added
 - `__tag` to the PopState events dispatched by `navigate`
 
 ## [3.0.0] - 2021-11-02
 ### Changed
-- **BREAKING**:`usePath` returns `decodeURIComponent`-ed path
-- **BREAKING**:`useRoutes`, `useMatch`, and `usePathParams` match paths that have been `decodeURIComponent`-ed (e.g. `/weird (route)` will match a path of `/weird%20(route)`)
+- **BREAKING**: `usePath` returns `decodeURIComponent`-ed path
+- **BREAKING**: `useRoutes`, `useMatch`, and `usePathParams` match paths that have been `decodeURIComponent`-ed (e.g. `/weird (route)` will match a path of `/weird%20(route)`)
 - **BREAKING**: type `RouteParams` renamed to `Routes`
 - **BREAKING**: `usePathParams` return type now depends on the input params. When a string it returns just the props, when an array it returns `[path, props]`
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.0.0] - Unreleased
 ### Added
 - `useHistory`
-- **BREAKING**: `useLocationChange` is a new hook that uses a `window.location`-like object instead of the _path_
 - `usePath`
 ### Changed
 - **BREAKING**: `navigate` now has `options` object instead of overloads
 - **BREAKING**: `useNavigate` uses updated `navigate` params
-- **BREAKING**: `useLocationChange` has been renamed to `usePath`### Fixed
+- **BREAKING**: `useLocationChange` now invokes the setter with a `RavigerLocation` object instead of the `path` string
 ### Fixed
 -  `usePath` getting an old path if `navigate` was called during the initial render
 

--- a/docs/api/RouterProvider.md
+++ b/docs/api/RouterProvider.md
@@ -1,7 +1,7 @@
 ---
 title: "RouterProvider"
 permalink: /router-provider/
-nav_order: 99
+nav_order: 59
 ---
 
 # STOP

--- a/docs/api/navigate.md
+++ b/docs/api/navigate.md
@@ -11,12 +11,18 @@ This function causes programmatic navigation and causes all **raviger** hooks to
 ## API
 
 ```typescript
-export function navigate(url: string, replace?: boolean): void
 export function navigate(
   url: string,
-  query?: QueryParam | URLSearchParams,
-  replace?: boolean,
-  state?: unknown
+  options?: {
+    /**
+     * Use a `replace` instead of `push` for navigation
+     * @default false */
+    replace?: boolean
+    /** Values to serialize as a querystring, which will be appended to the `url` */
+    query?: QueryParam | URLSearchParams
+    /**  value to pass as the state/data to history push/replace*/
+    state?: unknown
+  }
 ): void
 ```
 
@@ -42,33 +48,33 @@ import { navigate } from 'raviger'
 
 export async function createUser () {
   let user = await createUser()
-  navigate(`/users/${user.id}`, true)
+  navigate(`/users/${user.id}`, { replace: true })
 }
 ```
 
 ## Navigating with Query Params
 
-To navigate with a serialized query string pass an object as the second parameter.
+To navigate with a serialized query string pass an object to the `query` option.
 
 ```jsx
 import { navigate } from 'raviger'
 
 export async function createUser () {
   let user = await createUser()
-  navigate(`/users/${user.id}` { ref: 'create page' })
+  navigate(`/users/${user.id}`, { query: { ref: 'create page' }})
 }
 ```
 
 ## Navigating with History State
 
-By default the `state` is `null`. You can control the `state` passed to `history.pushState | history.replaceState` using the fourth parameter
+By default the `state` is `null`. You can control the `state` passed to `history.pushState | history.replaceState` using the `state` option.
 
 ```jsx
 import { navigate } from 'raviger'
 
 export async function createUser () {
   let user = await createUser()
-  navigate(`/users/${user.id}`, undefined, undefined, { user: user })
+  navigate(`/users/${user.id}`, { state: { user: user } })
 }
 ```
 

--- a/docs/api/useNavigationPrompt.md
+++ b/docs/api/useNavigationPrompt.md
@@ -1,7 +1,7 @@
 ---
 title: "useNavigationPrompt"
 permalink: /use-navigation-prompt/
-date: 2019-10-26T11:32:24-07:00
+nav_order: 58
 ---
 
 # `useNavigationPrompt`

--- a/docs/guides/migration_to_v4.md
+++ b/docs/guides/migration_to_v4.md
@@ -1,0 +1,59 @@
+---
+title: "Migration Guide - v4"
+permalink: /migraiton-to-v4/
+nav_order: 99
+---
+
+# v4 Migration Guide
+
+Raviger v4 comes with several high-impact breaking changes.
+
+- **BREAKING**: `navigate` now has `options` object instead of overloads
+- **BREAKING**: `useNavigate` uses updated `navigate` params
+- **BREAKING**: `useLocationChange` now invokes the setter with a `RavigerLocation` object instead of the `path`
+
+## navigate
+
+The changes to `navigate` create a more readable API but require manual changes to migrate to. This guide will provide some find/replace regexs, but they do not account for calls that might be broken onto multiple lines. You will need to inspect every call to `navigate` in your app to ensure it is changed correctly.
+
+Here are some sample migrations
+
+
+```js
+// Replace
+/*
+  find: navigate\((.+?)(, (true|false))\)
+  replace: navigate($1, { replace: $3 })
+*/
+navigate('/path', true) // -> navigate('/path', { replace: true })
+navigate('/path', false) // -> navigate('/path', { replace: false })
+
+// Query
+/*
+  find: navigate\((.+?),\s?(\{.+?\})\)
+  replace: navigate($1, { query: $2 })
+*/
+navigate('/path', { name: 'raviger' }) // -> navigate('/path', { query: { name: 'raviger' } })
+
+// State
+navigate('/path', undefined, undefined, { name: 'raviger'}) // -> navigate('/path', { state: { name: 'raviger' } })
+```
+
+The old `navigate` signature had complex combinations of overloads, so it is unlikely that simple substitutions will cover all the cases in even smaller applications. I'm sorry for the pain this change is going to cause, and doubly sorry because I already knew of the code smell of boolean arguments in functions with more than two parameters. I should have used an **options object** to begin with and I won't be making exceptions like this again.
+
+
+## useLocationChange
+
+Before v4 useLocationChange provided just the **path** to its `setFn`. It now provides a `window.location` like object that contains a `path` (and `pathname`, just to be consistent with `window.location`). While this new signature is strictly more useful, changes to your application can be avoided by adding a small utility method that emulates the previous behavior. You can replace all old usage of `useLocationChange` with this wrapper and be done.
+
+```typescript
+export function usePathChange(
+  setFn: (path: string | null) => void,
+  options: LocationChangeOptionParams = {}
+): void {
+  useLocationChange(
+    useCallback((location: RavigerLocation) => setFn(location.path), [setFn]),
+    options
+  )
+}
+```

--- a/example/package.json
+++ b/example/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@types/react": "^17.0.16",
     "@types/react-dom": "^17.0.9",
-    "parcel": "^2.0.0",
+    "parcel": "^2.3.2",
     "typescript": "^4.3.5"
   }
 }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,15 +1,24 @@
-import * as React from 'react'
-import {} from 'react-dom'
+// eslint-disable-next-line import/no-extraneous-dependencies
+import React from 'react'
 
-import { useRoutes, Link, usePath, useQueryParams, Redirect } from '../../src/main'
+import {
+  useRoutes,
+  Link,
+  usePath,
+  useQueryParams,
+  Redirect,
+  navigate,
+  useHistory,
+} from '../../src/main'
 import Nav from './Nav'
 import Form from './Form'
 
 const routes = {
-  '/': () => <span>Home</span>,
+  '/': () => <Home />,
   '/about': () => <span>about</span>,
   '/contact': () => <span>contact</span>,
   '/form': () => <Form />,
+  '/error': () => <Error />,
   '/weird (route)': () => <span>Weird Route</span>,
   '/users/:userId': ({ userId }: { userId: string }) => <span>User: {userId}</span>,
   '/filter': () => <Filter />,
@@ -20,11 +29,11 @@ const routes = {
 }
 
 let renders = 0
-const App = () => {
+function App(): JSX.Element {
   renders++
   const route = useRoutes(routes)
   const path = usePath()
-  // console.log('rendered', renders)
+  console.log('rendered', renders, route?.props?.children?.type?.name)
   return (
     <div>
       <Nav>
@@ -55,6 +64,69 @@ const App = () => {
 // }
 
 export default App
+
+function Home(): JSX.Element {
+  console.log('rendering Home')
+
+  return (
+    <div>
+      <p>Home</p>
+      <button
+        onClick={() => {
+          console.log('replace clicked, so navigating to /error')
+          navigate('/error', {
+            replace: true,
+            state: {
+              historyState: 'yes',
+            },
+          })
+        }}
+      >
+        Go to Error (Replace)
+      </button>
+      <button
+        onClick={() => {
+          console.log('push clicked, so navigating to /error')
+          navigate('/error', {
+            replace: false,
+            state: {
+              historyState: 'yes',
+            },
+          })
+        }}
+      >
+        Go to Error (Push)
+      </button>
+    </div>
+  )
+}
+
+function Error(): JSX.Element | null {
+  console.log('rendering /error')
+
+  const { state } = useHistory()
+
+  if (!state) {
+    console.log('no history state, so navigating to /')
+    navigate('/')
+    return null
+  }
+
+  return (
+    <div>
+      <p>Error</p>
+      <p>{JSON.stringify(state)}</p>
+      <button
+        onClick={() => {
+          console.log('button clicked, so navigating to /')
+          navigate('/')
+        }}
+      >
+        Go to main
+      </button>
+    </div>
+  )
+}
 
 const DeepAbout = () => (
   <Nav>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raviger",
-  "version": "4.0.0-2",
+  "version": "4.0.0-3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "raviger",
-      "version": "4.0.0-2",
+      "version": "4.0.0-3",
       "license": "MIT",
       "devDependencies": {
         "@kyeotic/eslint-config": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raviger",
-  "version": "4.0.0-0",
+  "version": "4.0.0-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "raviger",
-      "version": "4.0.0-0",
+      "version": "4.0.0-1",
       "license": "MIT",
       "devDependencies": {
         "@kyeotic/eslint-config": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raviger",
-  "version": "4.0.0-1",
+  "version": "4.0.0-2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "raviger",
-      "version": "4.0.0-1",
+      "version": "4.0.0-2",
       "license": "MIT",
       "devDependencies": {
         "@kyeotic/eslint-config": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raviger",
-  "version": "3.1.0",
+  "version": "4.0.0-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "raviger",
-      "version": "3.1.0",
+      "version": "4.0.0-0",
       "license": "MIT",
       "devDependencies": {
         "@kyeotic/eslint-config": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raviger",
-  "version": "4.0.0-1",
+  "version": "4.0.0-2",
   "description": "React routing with hooks",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "size-limit": [
     {
       "path": "dist/main.js",
-      "limit": "2.8kb"
+      "limit": "2.9kb"
     },
     {
       "webpack": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raviger",
-  "version": "4.0.0-0",
+  "version": "4.0.0-1",
   "description": "React routing with hooks",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "mkdirp": "^1.0.4",
     "np": "^7.5.0",
     "npm-run-all": "^4.1.5",
-    "prettier": "^2.3.2",
+    "prettier": "^2.5.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raviger",
-  "version": "3.1.0",
+  "version": "4.0.0-0",
   "description": "React routing with hooks",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raviger",
-  "version": "4.0.0-2",
+  "version": "4.0.0-3",
   "description": "React routing with hooks",
   "keywords": [
     "react",

--- a/src/Link.tsx
+++ b/src/Link.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, forwardRef, Ref } from 'react'
 
 import { navigate } from './navigate'
-import { useBasePath, useFullPath } from './path'
+import { useBasePath, useFullPath } from './location'
 
 export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   href: string

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -21,6 +21,8 @@ export function RouterProvider({
   children?: React.ReactNode
 }): JSX.Element {
   return (
+    // The ordering here is important, the basePath will change less often
+    // So putting it on the outside reduces its need to re-render
     <BasePathContext.Provider value={basePath}>
       <PathContext.Provider value={path ?? null}>{children}</PathContext.Provider>
     </BasePathContext.Provider>

--- a/src/location.ts
+++ b/src/location.ts
@@ -54,6 +54,8 @@ export function usePath(basePath?: string): string | null {
   useLocationChange(onChange, {
     basePath,
     inheritBasePath: !basePath,
+    // Use on initial to handle to force state updates from on-mount navigation
+    onInitial: true,
   })
 
   return contextPath || getFormattedPath(basePath)

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ export {
   useBasePath,
   usePathChange,
   useLocationChange,
+  useHistory,
 } from './location'
 export type { PathChangeSetFn, LocationChangeSetFn, LocationChangeOptionParams } from './location'
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,11 +15,10 @@ export {
   useHash,
   useFullPath,
   useBasePath,
-  usePathChange,
   useLocationChange,
   useHistory,
 } from './location'
-export type { PathChangeSetFn, LocationChangeSetFn, LocationChangeOptionParams } from './location'
+export type { LocationChangeSetFn, LocationChangeOptionParams } from './location'
 
 export { useQueryParams } from './querystring'
 export type { QueryParam, setQueryParamsOptions } from './querystring'

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,10 +9,16 @@ export type { RedirectProps, UseRedirectProps } from './redirect'
 export { Link, ActiveLink } from './Link'
 
 export { navigate, useNavigate, useNavigationPrompt } from './navigate'
-export type { NavigateWithReplace, NavigateWithQuery } from './navigate'
 
-export { usePath, useHash, useFullPath, useBasePath, useLocationChange } from './path'
-export type { LocationChangeSetFn, LocationChangeOptionParams } from './path'
+export {
+  usePath,
+  useHash,
+  useFullPath,
+  useBasePath,
+  usePathChange,
+  useLocationChange,
+} from './location'
+export type { PathChangeSetFn, LocationChangeSetFn, LocationChangeOptionParams } from './location'
 
 export { useQueryParams } from './querystring'
 export type { QueryParam, setQueryParamsOptions } from './querystring'

--- a/src/navigate.ts
+++ b/src/navigate.ts
@@ -1,6 +1,6 @@
 import { useCallback, useLayoutEffect } from 'react'
 
-import { useBasePath } from './path'
+import { useBasePath } from './location'
 import { isNode } from './node'
 import type { QueryParam } from './querystring'
 import {
@@ -10,10 +10,6 @@ import {
   defaultPrompt,
   undoNavigation,
 } from './intercept'
-
-export interface NavigateWithReplace {
-  (url: string, replace?: boolean): void
-}
 
 export interface NavigateOptions {
   /**

--- a/src/querystring.ts
+++ b/src/querystring.ts
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react'
 
 import { navigate } from './navigate'
 import { isNode, getSsrPath } from './node'
-import { getCurrentPath, getCurrentHash, usePathChange } from './location'
+import { getCurrentPath, getCurrentHash, useLocationChange } from './location'
 
 export interface QueryParam {
   [key: string]: any
@@ -34,7 +34,7 @@ export function useQueryParams<T extends QueryParam>(
   // Update state when route changes
   const updateQuery = useCallback(() => setQuerystring(getQueryString()), [])
 
-  usePathChange(updateQuery)
+  useLocationChange(updateQuery)
   return [parseFn(querystring), setQueryParams]
 }
 

--- a/src/querystring.ts
+++ b/src/querystring.ts
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react'
 
 import { navigate } from './navigate'
 import { isNode, getSsrPath } from './node'
-import { getCurrentPath, getCurrentHash, useLocationChange } from './path'
+import { getCurrentPath, getCurrentHash, usePathChange } from './location'
 
 export interface QueryParam {
   [key: string]: any
@@ -34,7 +34,7 @@ export function useQueryParams<T extends QueryParam>(
   // Update state when route changes
   const updateQuery = useCallback(() => setQuerystring(getQueryString()), [])
 
-  useLocationChange(updateQuery)
+  usePathChange(updateQuery)
   return [parseFn(querystring), setQueryParams]
 }
 

--- a/src/redirect.ts
+++ b/src/redirect.ts
@@ -55,7 +55,7 @@ export function useRedirect(
 
   useLayoutEffect(() => {
     if (currentPath === predicateUrl) {
-      navigate(url, undefined, replace)
+      navigate(url, { replace })
     }
   }, [predicateUrl, url, replace, currentPath])
 }

--- a/src/redirect.ts
+++ b/src/redirect.ts
@@ -1,6 +1,6 @@
 import { useLayoutEffect } from 'react'
 
-import { getCurrentHash, usePath } from './path'
+import { getCurrentHash, usePath } from './location'
 import { navigate } from './navigate'
 import { QueryParam, useQueryParams } from './querystring'
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -160,7 +160,6 @@ function usePathOptions(
   { basePath, matchTrailingSlash = true }: PathParamOptions
 ): [string | null, RouteMatcher[]] {
   const routes = (!Array.isArray(routeOrRoutes) ? [routeOrRoutes] : routeOrRoutes) as string[]
-
   const matchers = useMatchers(routes)
 
   return [trailingMatch(usePath(basePath), matchTrailingSlash), matchers]

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState, useLayoutEffect } from 'react'
 
 import { RouterProvider } from './context'
 import { isNode, setSsrPath, getSsrPath } from './node'
-import { getFormattedPath, usePath } from './path'
+import { getFormattedPath, usePath } from './location'
 import type { NonEmptyRecord, Split, ValueOf } from './types'
 
 const emptyPathResult: [null, null] = [null, null]

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,8 +1,8 @@
-import React, { useMemo, useState, useLayoutEffect } from 'react'
+import React, { useMemo } from 'react'
 
 import { RouterProvider } from './context'
 import { isNode, setSsrPath, getSsrPath } from './node'
-import { getFormattedPath, usePath } from './location'
+import { /* getFormattedPath, */ usePath } from './location'
 import type { NonEmptyRecord, Split, ValueOf } from './types'
 
 const emptyPathResult: [null, null] = [null, null]
@@ -54,10 +54,11 @@ export function useRoutes<Path extends string>(
     If useRoutes hacks itself into the latest path nothing bad happens (...afaik)
   */
 
-  const path = usePath(basePath) && getFormattedPath(basePath)
+  const path = usePath(basePath)
 
   // Handle potential <Redirect /> use in routes
-  useRedirectDetection(basePath, path)
+  // console.log('pre-detect', path, usePath(basePath), getFormattedPath(basePath))
+  // useRedirectDetection(basePath, usePath(basePath))
 
   // Get the current route
   const route = useMatchRoute(routes, path, {
@@ -228,14 +229,16 @@ function hashParams(params: string[]): string {
 // the `navigate` call in useRedirect *does* cause usePath/useLocationChange
 // to fire, but without this hack useRoutes suppresses the update
 // TODO: find a better way to cause a synchronous update from useRoutes
-function useRedirectDetection(basePath: string, path: string | null) {
-  const [, forceRender] = useState(false)
-  useLayoutEffect(() => {
-    if (path !== getFormattedPath(basePath)) {
-      forceRender((s) => !s)
-    }
-  }, [basePath, path])
-}
+// function useRedirectDetection(basePath: string, path: string | null) {
+//   const [, updateState] = useState({})
+//   const forceRender = useCallback(() => updateState({}), [])
+
+//   useLayoutEffect(() => {
+//     if (path !== getFormattedPath(basePath)) {
+//       forceRender()
+//     }
+//   }, [forceRender, basePath, path])
+// }
 
 function trailingMatch(path: string | null, matchTrailingSlash: boolean): string | null {
   if (path === null) return path

--- a/test/location.spec.tsx
+++ b/test/location.spec.tsx
@@ -1,32 +1,24 @@
 import React, { useCallback, useEffect } from 'react'
 import { render, act, fireEvent } from '@testing-library/react'
-import {
-  navigate,
-  usePathChange,
-  usePath,
-  useRoutes,
-  useHash,
-  PathChangeSetFn,
-  RouteParams,
-} from '../src/main'
+import { navigate, useLocationChange, usePath, useRoutes, useHash, RouteParams } from '../src/main'
 
 beforeEach(() => {
   act(() => navigate('/'))
 })
 
-describe('usePathChange', () => {
+describe('useLocationChange', () => {
   function Route({
     onChange,
     isActive,
     basePath,
     onInitial = false,
   }: {
-    onChange: PathChangeSetFn
+    onChange: (path: string) => void
     isActive?: boolean
     basePath?: string
     onInitial?: boolean
   }) {
-    usePathChange(onChange, { isActive, basePath, onInitial })
+    useLocationChange(({ path }) => onChange(path), { isActive, basePath, onInitial })
     return null
   }
   test("setter doesn't get updated on mount", async () => {

--- a/test/location.tsx
+++ b/test/location.tsx
@@ -7,7 +7,6 @@ import {
   useRoutes,
   useHash,
   PathChangeSetFn,
-  LocationChangeSetFn,
   RouteParams,
 } from '../src/main'
 

--- a/test/navigate.spec.tsx
+++ b/test/navigate.spec.tsx
@@ -27,7 +27,7 @@ describe('useNavigate', () => {
     return (
       <button
         onClick={() => {
-          navigateWithBasePath(newPath, query, replace)
+          navigateWithBasePath(newPath, { query, replace })
         }}
       >
         click to navigate
@@ -222,39 +222,39 @@ describe('navigate', () => {
     window.history.pushState = jest.fn()
     const url = '/foo'
 
-    navigate(url, false)
+    navigate(url, { replace: false })
     expect(window.history.pushState).toHaveBeenCalled()
     jest.clearAllMocks()
 
-    navigate(url, true)
+    navigate(url, { replace: true })
     expect(window.history.replaceState).toHaveBeenCalled()
     jest.clearAllMocks()
 
-    navigate(url, null, true)
+    navigate(url, { replace: true })
     expect(window.history.replaceState).toHaveBeenCalled()
     jest.clearAllMocks()
 
-    navigate(url, null, false)
+    navigate(url, { replace: false })
     expect(window.history.pushState).toHaveBeenCalled()
     jest.clearAllMocks()
 
-    navigate(url, undefined, true)
+    navigate(url, { replace: true })
     expect(window.history.replaceState).toHaveBeenCalled()
     jest.clearAllMocks()
 
-    navigate(url, undefined, false)
+    navigate(url, { replace: false })
     expect(window.history.pushState).toHaveBeenCalled()
     jest.clearAllMocks()
 
-    navigate(url, {})
+    navigate(url, { query: {} })
     expect(window.history.pushState).toHaveBeenCalled()
     jest.clearAllMocks()
 
-    navigate(url, {}, true)
+    navigate(url, { replace: true, query: {} })
     expect(window.history.replaceState).toHaveBeenCalled()
     jest.clearAllMocks()
 
-    navigate(url, {}, false)
+    navigate(url, { replace: false, query: {} })
     expect(window.history.pushState).toHaveBeenCalled()
     jest.clearAllMocks()
   })

--- a/test/querystring.spec.tsx
+++ b/test/querystring.spec.tsx
@@ -12,21 +12,21 @@ describe('useQueryParams', () => {
     return <span data-testid="label">{JSON.stringify(query)}</span>
   }
   test('parses query', async () => {
-    act(() => navigate('/about', { foo: 'bar' }))
+    act(() => navigate('/about', { query: { foo: 'bar' } }))
     const { getByTestId } = render(<Route />)
     expect(getByTestId('label')).toHaveTextContent(JSON.stringify({ foo: 'bar' }))
   })
   test('navigation updates query', async () => {
     const q1 = { foo: 'bar' }
     const q2 = { bar: 'foo' }
-    act(() => navigate('/about', q1))
+    act(() => navigate('/about', { query: q1 }))
     const { getByTestId } = render(<Route />)
     expect(getByTestId('label')).toHaveTextContent(JSON.stringify(q1))
-    act(() => navigate('/check', q2))
+    act(() => navigate('/check', { query: q2 }))
     expect(getByTestId('label')).toHaveTextContent(JSON.stringify(q2))
     // Jest doesn't appear to do this...
     // act(() => window.history.back())
-    act(() => navigate('/about', q1))
+    act(() => navigate('/about', { query: q1 }))
     expect(getByTestId('label')).toHaveTextContent(JSON.stringify(q1))
   })
 })
@@ -41,14 +41,14 @@ describe('setQueryParams', () => {
     )
   }
   test('updates query', async () => {
-    act(() => navigate('/about', { bar: 'foo' }))
+    act(() => navigate('/about', { query: { bar: 'foo' } }))
     const { getByTestId } = render(<Route replace />)
 
     act(() => void fireEvent.click(getByTestId('update')))
     expect(document.location.search).toEqual('?foo=bar')
   })
   test('handles encoded values', async () => {
-    act(() => navigate('/about', { foo: 'foo' }))
+    act(() => navigate('/about', { query: { foo: 'foo' } }))
     const { getByTestId } = render(<Route replace={false} foo={'%100'} />)
 
     act(() => void fireEvent.click(getByTestId('update')))
@@ -56,7 +56,7 @@ describe('setQueryParams', () => {
     expect(getByTestId('update')).toHaveTextContent('Set Query: %100')
   })
   test('merges query', async () => {
-    act(() => navigate('/about', { bar: 'foo' }))
+    act(() => navigate('/about', { query: { bar: 'foo' } }))
     const { getByTestId } = render(<Route replace={false} />)
 
     act(() => void fireEvent.click(getByTestId('update')))
@@ -64,7 +64,7 @@ describe('setQueryParams', () => {
     expect(document.location.search).toContain('foo=bar')
   })
   test('merges query without null', async () => {
-    act(() => navigate('/about', { bar: 'foo' }))
+    act(() => navigate('/about', { query: { bar: 'foo' } }))
     const { getByTestId } = render(<Route replace={false} foo={null} />)
 
     act(() => void fireEvent.click(getByTestId('update')))

--- a/test/router.spec.tsx
+++ b/test/router.spec.tsx
@@ -348,7 +348,7 @@ describe('navigate', () => {
 
   test('allows query string objects', async () => {
     // console.log(URLSearchParams)
-    act(() => navigate('/', { q: 'name', env: 'test' }))
+    act(() => navigate('/', { query: { q: 'name', env: 'test' } }))
     expect(window.location.search).toContain('q=name')
     expect(window.location.search).toContain('env=test')
   })


### PR DESCRIPTION
closes #113
closes #115
closes #116 
closes #117

This PR replaces #114

I would like to have a codemod for the change to `navigate`, but if I am being realistic I don't have the energy to put one together. I just started a new job and will be moving out of state in a few months, so my OSS time is extremely limited. If someone wants to write one I would be very grateful. 

**Changelog Preview**
---
## [4.0.0] - Unreleased
### Added
- `useHistory`
- `usePath`
### Changed
- **BREAKING**: `navigate` now has `options` object instead of overloads
- **BREAKING**: `useNavigate` uses updated `navigate` params
- **BREAKING**: `useLocationChange` now invokes the setter with a `RavigerLocation` object instead of the `path` string
### Fixed
-  `usePath` getting an old path if `navigate` was called during the initial render
---

~The docs have not yet been updated for any of this. **External Contributions Welcome**~
Edit: docs have been updated

I have released a beta for this code, it can be installed with

```
npm i raviger@beta
// OR
npm i raviger@4.0.0-2
```