### PR TITLE
fix: Add className type declaration for Link

### DIFF
--- a/src/Link.tsx
+++ b/src/Link.tsx
@@ -7,6 +7,7 @@ export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement>
   href: string
   basePath?: string
   children?: React.ReactNode
+  className?: string
 }
 export type LinkRef = HTMLAnchorElement | null
 


### PR DESCRIPTION
# The problem

The className definition is missing on the Link element, even though _className_ is used to construct the element's classes. This results in a TS error

```
Type '{ children: Element[]; className: string; href: string; key: string; }' is not assignable to type 'IntrinsicAttributes & LinkProps & { ref?: any; }'.
  Property 'className' does not exist on type 'IntrinsicAttributes & LinkProps & { ref?: any; }'.ts(2322)
  ```
    
 # The fix
 
 Add className to the type definition