### PR TITLE
fix(): undefined classname

### DIFF
--- a/src/Link.tsx
+++ b/src/Link.tsx
@@ -57,8 +57,10 @@ function ActiveLink(
   let { href } = props
   href = absolutePathName(getLinkHref(href, basePath))
 
-  if (exactActiveClass && fullPath === href) className += ` ${exactActiveClass}`
-  if (activeClass && fullPath.startsWith(href)) className += ` ${activeClass}`
+  if (exactActiveClass && fullPath === href)
+    className = `${className ?? ``} ${exactActiveClass}`.trim()
+  if (activeClass && fullPath.startsWith(href))
+    className = `${className ?? ``} ${activeClass}`.trim()
 
   return <RefLink {...props} basePath={basePath} className={className} ref={ref} />
 }

--- a/test/Link.spec.tsx
+++ b/test/Link.spec.tsx
@@ -198,4 +198,21 @@ describe('ActiveLink', () => {
     expect(getByTestId('link')).toHaveClass('active')
     expect(getByTestId('link')).toHaveClass('exact')
   })
+
+  test('empty classname on active link', async () => {
+    const { getByTestId } = render(
+      <ActiveLink href="/foo" activeClass="extra" exactActiveClass="double" data-testid="link">
+        go to foo
+      </ActiveLink>
+    )
+
+    act(() => navigate('/'))
+    expect(getByTestId('link')).not.toHaveAttribute('class')
+
+    act(() => navigate('/foo'))
+    expect(getByTestId('link')).toHaveAttribute('class', 'double extra')
+
+    act(() => navigate('/foo/bar'))
+    expect(getByTestId('link')).toHaveAttribute('class', 'extra')
+  })
 })


### PR DESCRIPTION
added `undefined` to className if no className is set.