### PR TITLE
fix: useHash get from window instead of event

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -6,6 +6,7 @@ import {
   Link,
   usePath,
   useQueryParams,
+  useHash,
   Redirect,
   navigate,
   useHistory,
@@ -17,6 +18,7 @@ const routes = {
   '/': () => <Home />,
   '/about': () => <span>about</span>,
   '/contact': () => <span>contact</span>,
+  '/hash-debug': () => <HashDebug />,
   '/form': () => <Form />,
   '/error': () => <Error />,
   '/weird (route)': () => <span>Weird Route</span>,
@@ -41,6 +43,7 @@ function App(): JSX.Element {
         <Link href="/about">About</Link>
         <Link href="/contact">Contact</Link>
         <Link href="/form">Form</Link>
+        <Link href="/hash-debug">Hash Debug</Link>
         <Link href={`/${encodeURIComponent('weird (route)')}`}>Weird (Route)</Link>
         <Link href="/users/1">Tom</Link>
         <Link href="/users/2">Jane</Link>
@@ -97,6 +100,18 @@ function Home(): JSX.Element {
       >
         Go to Error (Push)
       </button>
+    </div>
+  )
+}
+
+function HashDebug() {
+  const hash = useHash()
+
+  return (
+    <div>
+      <p>current hash {hash}</p>
+      <a href="#first">First</a>
+      <a href="#second">Second</a>
     </div>
   )
 }

--- a/src/location.ts
+++ b/src/location.ts
@@ -75,13 +75,11 @@ export function useFullPath(): string {
 
 export function useHash({ stripHash = true } = {}): string {
   const [hash, setHash] = useState(window.location.hash)
-  const handleHash = useCallback(
-    ({ hash: newHash }) => {
-      if (newHash === hash) return
-      setHash(newHash)
-    },
-    [setHash, hash]
-  )
+  const handleHash = useCallback(() => {
+    const newHash = window.location.hash
+    if (newHash === hash) return
+    setHash(newHash)
+  }, [setHash, hash])
 
   useLayoutEffect(() => {
     window.addEventListener('hashchange', handleHash, false)

--- a/test/location.spec.tsx
+++ b/test/location.spec.tsx
@@ -276,8 +276,9 @@ describe('useHash', () => {
   test('returns updated hash', async () => {
     act(() => navigate('/#test'))
     const { getByTestId } = render(<Route />)
-    act(() => navigate('/#updated'))
+    expect(getByTestId('hash')).toHaveTextContent('test')
 
+    act(() => navigate('/#updated'))
     expect(getByTestId('hash')).toHaveTextContent('updated')
   })
   test('returns hash without stripping when stripHash is false', async () => {


### PR DESCRIPTION
closes #126 

Reverts change to `useHash` that looked on the event instead of the window for the new hash. The event doesn't have the prop, only the full url.