### PR TITLE
Support custom regex to match route path parts

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -212,7 +212,7 @@ function createRouteMatcher(path: string, {
     path,
     regex: new RegExp(
       `${path.substr(0, 1) === '*' ? '' : '^'}${escapeRegExp(path)
-        .replace(partRegex, '([^/]+)')
+        .replace(partMatcher, '([^/]+)')
         .replace(/\*/g, '')}${path.substr(-1) === '*' ? '' : '$'}`,
       'i'
     ),


### PR DESCRIPTION
Should fix #129, but requires a bit more testing, and documentation. I didn't finish this because [my problem lay elsewhere](https://github.com/vitejs/vite/issues/2245), but am sharing it anyway for whoever needs it.