### PR TITLE
Adds support for history replace in `useQueryParams`

### DIFF
--- a/docs/api/useQueryParams.md
+++ b/docs/api/useQueryParams.md
@@ -15,12 +15,7 @@ A hook for reading and updating the query string parameters on the page. Updates
 export function useQueryParams<T extends QueryParam>(
   parseFn?: (query: string) => T,
   serializeFn?: (query: Partial<T>) => string
-): [T, (query: T, options?: setQueryParamsOptions) => void]
-
-export interface setQueryParamsOptions {
-  replace?: boolean
-  historyReplace?: boolean
-}
+): [T, (query: T, options?: { replace?: boolean, historyReplace?: boolean }) => void]
 ```
 
 ## Basic

--- a/docs/api/useQueryParams.md
+++ b/docs/api/useQueryParams.md
@@ -12,10 +12,15 @@ A hook for reading and updating the query string parameters on the page. Updates
 
 
 ```typescript
-export function useQueryParams(
-  parseFn?: (query: string) => QueryParam,
-  serializeFn?: (query: QueryParam) => string
-): [QueryParam, (query: QueryParam, replace?: boolean) => void]
+export function useQueryParams<T extends QueryParam>(
+  parseFn?: (query: string) => T,
+  serializeFn?: (query: Partial<T>) => string
+): [T, (query: T, options?: setQueryParamsOptions) => void]
+
+export interface setQueryParamsOptions {
+  replace?: boolean
+  historyReplace?: boolean
+}
 ```
 
 ## Basic
@@ -44,7 +49,7 @@ function UserList ({ users }) {
 
 ## Updating the Query with merge
 
-The second return value from `useQueryParams` is a function that updates the query string. By default it overwrites the entire query, but it can merge with the query object by setting the second param to `{ replace: false }`.
+The second return value from `useQueryParams` is a function that updates the query string. By default it overwrites the entire query, but it can merge with the query object by setting the `replace` option to `false`.
 
 ```jsx
 import { useQueryParams } from 'raviger'
@@ -58,6 +63,25 @@ function UserList ({ users }) {
 ```
 
 The `replace: false` setting also preserves the `location.hash`. The intent should be thought of as updating only the part of the URL that the `setQuery` object describes.
+
+You can also control whether the navigation replaces the current history entry by using the `historyReplace` option:
+
+```jsx
+import { useQueryParams } from 'raviger'
+
+function UserList ({ users }) {
+  const [{ startsWith }, setQuery] = useQueryParams()
+  
+  // This will update the query params without adding a new history entry
+  const handleChange = (e) => {
+    setQuery({ startsWith: e.target.value}, { historyReplace: true })
+  }
+  
+  return (
+    <input value={startsWith || ''} onChange={handleChange} />
+  )
+}
+```
 
 > Warning: using `setQuery` inside of a `useEffect` (or other on-mount/on-update lifecycle methods) can result in unwanted navigations, which show up as duplicate entries in the browser history stack.
 

--- a/src/querystring.ts
+++ b/src/querystring.ts
@@ -11,6 +11,7 @@ export interface QueryParam {
 
 export interface setQueryParamsOptions {
   replace?: boolean
+  historyReplace?: boolean
 }
 
 export function useQueryParams<T extends QueryParam>(
@@ -19,7 +20,7 @@ export function useQueryParams<T extends QueryParam>(
 ): [T, (query: T, options?: setQueryParamsOptions) => void] {
   const [querystring, setQuerystring] = useState(getQueryString())
   const setQueryParams = useCallback(
-    (params, { replace = true } = {}) => {
+    (params, { replace = true, historyReplace = false } = {}) => {
       let path = getCurrentPath()
       params = replace ? params : { ...parseFn(querystring), ...params }
       const serialized = serializeFn(params).toString()
@@ -27,7 +28,7 @@ export function useQueryParams<T extends QueryParam>(
       if (serialized) path += '?' + serialized
       if (!replace) path += getCurrentHash()
 
-      navigate(path)
+      navigate(path, { replace: historyReplace })
     },
     [querystring, parseFn, serializeFn]
   )


### PR DESCRIPTION
Added support for history replace when using `setQueryString` of `useQueryParams` by setting `historyReplace` option.


#### Associated Issues

- fixes #134